### PR TITLE
Update rootlogon.C

### DIFF
--- a/doc/rootlogon.C
+++ b/doc/rootlogon.C
@@ -46,7 +46,7 @@ if (cmsswbase.Length() > 0)
 
 }	
    	
-#include <iostream.h>
+#include <iostream>
 //#include <iomanip.h>
 #include <time.h>
 //#include "nicepalette.h"


### PR DESCRIPTION
Should use #include <iostream>, not iostream.h; the .h form is very old and deprecated since years.